### PR TITLE
feature/form-control-server-errors

### DIFF
--- a/addon/components/uxs-form-control.js
+++ b/addon/components/uxs-form-control.js
@@ -67,6 +67,7 @@ export default Component.extend(BEMComponent, PropTypeMixin, Testable, {
       compact: PropTypes.boolean,
     });
     this.initValidator();
+    this.initModelErrors();
   },
   getDefaultProps() {
     return {
@@ -80,6 +81,12 @@ export default Component.extend(BEMComponent, PropTypeMixin, Testable, {
     if (get(this, 'model')) {
       let propName = get(this, 'name');
       defineProperty(this, 'validator', oneWay(`model.validations.attrs.${propName}`));
+    }
+  },
+  initModelErrors() {
+    if (get(this, 'model')) {
+      let propName = get(this, 'name');
+      defineProperty(this, 'modelErrors', oneWay(`model.errors.${propName}`));
     }
   },
   // Events

--- a/addon/templates/components/uxs-form-control.hbs
+++ b/addon/templates/components/uxs-form-control.hbs
@@ -44,13 +44,16 @@
 {{#if hasError}}
   {{uxs-form-error error name=name disabled=disabled}}
 {{/if}}
-{{#each modelErrors as |modelError|}}
-  {{uxs-form-error modelError.message name=modelError.attribute disabled=disabled}}
-{{/each}}
-{{#if hasValidationError}}
-  {{uxs-form-error
-    (v-get model name 'message')
-    name=name
-    disabled=disabled
-  }}
+{{#if modelErrors.length}}
+  {{#each modelErrors as |modelError|}}
+    {{uxs-form-error modelError.message name=modelError.attribute disabled=disabled}}
+  {{/each}}
+{{else}}
+  {{#if hasValidationError}}
+    {{uxs-form-error
+      (v-get model name 'message')
+      name=name
+      disabled=disabled
+    }}
+  {{/if}}
 {{/if}}

--- a/addon/templates/components/uxs-form-control.hbs
+++ b/addon/templates/components/uxs-form-control.hbs
@@ -44,6 +44,9 @@
 {{#if hasError}}
   {{uxs-form-error error name=name disabled=disabled}}
 {{/if}}
+{{#each modelErrors as |modelError|}}
+  {{uxs-form-error modelError.message name=modelError.attribute disabled=disabled}}
+{{/each}}
 {{#if hasValidationError}}
   {{uxs-form-error
     (v-get model name 'message')


### PR DESCRIPTION
API model errors are stored in model.errors (See [DS.Errors](https://www.emberjs.com/api/ember-data/release/classes/DS.Errors)).

This PR displays these alongside the relevant form controls. Errors take precedent over validation messages.